### PR TITLE
Disable warn for console.error()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     ],
     // No need to enforce linebreak styles since "* text=auto" in .gitattributes will ensure LF is committed to the repo
     'linebreak-style': 'off',
+    'no-console': ['warn', { allow: ['error'] }],
   },
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
Eslint will no longer warn for conole.error() but will still warn for console.log() and console.warn().